### PR TITLE
Fix inverse behavior in optical_fft

### DIFF
--- a/src/chromatix/ops/fft.py
+++ b/src/chromatix/ops/fft.py
@@ -49,9 +49,9 @@ def optical_fft(
 
     # Doing the FFT
     if inverse:
-        u = norm * fftshift(fft(field.u, loop_axis))
-    else:
         u = norm * ifftshift(ifft(field.u, loop_axis))
+    else:
+        u = norm * fftshift(fft(field.u, loop_axis))
     return -1j * field.replace(u=u, dx=du)
 
 


### PR DESCRIPTION
Setting `inverse=True` was taking FFT instead of Inverse FFT. This patch fixes it.