### PR TITLE
remove phase and RI from plane wave generator

### DIFF
--- a/src/chromatix/functional/sources.py
+++ b/src/chromatix/functional/sources.py
@@ -97,13 +97,11 @@ def objective_point_source(
 def plane_wave(
     field: Field,
     power: float = 1.0,
-    phase: float = 0.0,
-    n: float = 1.00,
+    kykx: Optional[Array] = jnp.zeros(2),
     pupil: Optional[Callable[[Field], Field]] = None,
-    kykx: Optional[Array] = None,
 ) -> Field:
     """
-    Generates plane wave of given ``phase`` and ``power``.
+    Generates plane wave of given ``power``.
 
     Can also be given ``pupil`` and ``k`` vector.
 
@@ -112,21 +110,12 @@ def plane_wave(
             wave (should be empty).
         power: The total power that the result should be normalized to,
             defaults to 1.0.
-        phase: The phase of the plane wave in radians, defaults to 0.0.
-        n: the refractive index of the medium
         pupil: If provided, will be called on the field to apply a pupil.
         kykx: If provided, defines the orientation of the plane wave. Should be an
             array of shape `[2,]` in the format [ky, kx]. If provided, ``phase`` is
             ignored.
     """
-    if kykx is None:
-        u = jnp.exp(1j * jnp.full(field.shape, phase))
-    else:
-        kykx_norm = jnp.linalg.norm(kykx)
-        assert (
-            kykx_norm**2 <= (n * 2 * jnp.pi / field.spectrum) ** 2
-        ), "kx**2 + ky**2 must not be larger than (2*pi * n/wavelength)**2"
-        u = jnp.exp(1j * jnp.einsum("v, vbhwc->bhwc", kykx, field.grid))
+    u = jnp.exp(1j * (jnp.einsum("v, vbhwc->bhwc", kykx, field.grid)))
 
     field = field.replace(u=u)
 

--- a/src/chromatix/functional/sources.py
+++ b/src/chromatix/functional/sources.py
@@ -97,7 +97,7 @@ def objective_point_source(
 def plane_wave(
     field: Field,
     power: float = 1.0,
-    kykx: Optional[Array] = jnp.zeros(2),
+    kykx: Array = jnp.zeros(2),
     pupil: Optional[Callable[[Field], Field]] = None,
 ) -> Field:
     """
@@ -110,10 +110,9 @@ def plane_wave(
             wave (should be empty).
         power: The total power that the result should be normalized to,
             defaults to 1.0.
+        kykx: Defines the orientation of the plane wave. Should be an
+            array of shape `[2,]` in the format [ky, kx].
         pupil: If provided, will be called on the field to apply a pupil.
-        kykx: If provided, defines the orientation of the plane wave. Should be an
-            array of shape `[2,]` in the format [ky, kx]. If provided, ``phase`` is
-            ignored.
     """
     u = jnp.exp(1j * (jnp.einsum("v, vbhwc->bhwc", kykx, field.grid)))
 


### PR DESCRIPTION
Switching to a k-vector only version. Field is generated as:

$$U(x,y) = exp( j \cdot (k_x\cdot x + k_y \cdot y))$$

where $x,y$ come from the `Field.grid`. 

`Phase` and `n` arguments were removed.