### PR TITLE
Adding RandDiskGenerator to `utils.data`

### DIFF
--- a/src/chromatix/functional/propagation.py
+++ b/src/chromatix/functional/propagation.py
@@ -41,15 +41,15 @@ def transform_propagate(
     z = jnp.atleast_1d(z)
     z = rearrange(z, "z -> z 1 1 1")
     # Fourier normalization factor
-    L = field.spectrum * z / n  # lengthscale L
-    norm = field.dx ** 2 / L 
+    L = jnp.sqrt(field.spectrum * z / n)  # lengthscale L
+    norm = (field.dx / L) ** 2
     # Calculating input phase change
-    input_phase = jnp.pi * field.l2_sq_grid / L
+    input_phase = jnp.pi * field.l2_sq_grid / L**2
     # Calculating new scaled output coordinates
-    du = L / ((field.shape[1] + N_pad) * field.dx)
+    du = L**2 / ((field.shape[1] + N_pad) * field.dx)
     # Calculating output phase
     output_grid = field.l2_sq_grid * (du / field.dx) ** 2
-    output_phase = jnp.pi * output_grid / L
+    output_phase = jnp.pi * output_grid / L**2
     # Determining new field
     u = field.u * jnp.exp(1j * input_phase)
     u = center_pad(u, [0, int(N_pad / 2), int(N_pad / 2), 0], cval=cval)
@@ -65,7 +65,6 @@ def transfer_propagate(
     z: Union[float, Array],
     n: float,
     N_pad: int,
-    method: str = "Fresnel",
     cval: float = 0,
     kykx: Array = jnp.zeros((2,)),
     loop_axis: Optional[int] = None,
@@ -88,7 +87,7 @@ def transfer_propagate(
             to "full", in which case the output shape will include padding.
     """
     propagator = compute_transfer_propagator(
-        field.shape, field.dx, field.spectrum, z, n, N_pad, method, kykx
+        field.shape, field.dx, field.spectrum, z, n, N_pad, kykx
     )
     return kernel_propagate(field, propagator, N_pad, cval, loop_axis, mode)
 
@@ -156,10 +155,9 @@ def compute_transfer_propagator(
     z: Union[float, Array],
     n: float,
     N_pad: int,
-    method: str = "Fresnel",
     kykx: Array = jnp.zeros((2,)),
 ):
-    """Compute propagation kernel for Fresnel or ASM propagation.
+    """Compute propagation kernel for Fresnel propagation.
 
     Returns an array that can be multiplied with the Fourier transform of the
     incoming Field, as performed by kernel_propagate.
@@ -180,6 +178,7 @@ def compute_transfer_propagator(
     """
     z = jnp.atleast_1d(z)
     z = rearrange(z, "z -> z 1 1 1")
+    L = jnp.sqrt(jnp.complex64(spectrum * z / n))  # lengthscale L
     # TODO(dd): This calculation could probably go into Field
     dx = jnp.atleast_1d(dx)
     f = []
@@ -187,18 +186,7 @@ def compute_transfer_propagator(
         f.append(jnp.fft.fftfreq(shape[1] + N_pad, d=dx[..., d].squeeze()))
     f = jnp.stack(f, axis=-1)
     fx, fy = rearrange(f, "h c -> 1 h 1 c"), rearrange(f, "w c -> 1 1 w c")
-    
-    if method == 'ASM':
-        argument = (2 * np.pi)**2 * ((1. / spectrum) ** 2 -  (fx - kykx[1])** 2 - (fy - kykx[0]) ** 2)
-        tmp = np.sqrt(jnp.abs(argument))
-        phase = np.where(argument >= 0, tmp, 1j*tmp) * z # TODO make eve. removal optional
-    
-    elif method == 'Fresnel':
-        L = jnp.complex64(spectrum * z / n)  # lengthscale L
-        phase = -jnp.pi * L * ((fx - kykx[1]) ** 2 + (fy - kykx[0]) ** 2)
-        
-    else:
-        raise ValueError("Invalid method. Choose either 'Fresnel' or 'ASM'.")
+    phase = -jnp.pi * L**2 * ((fx - kykx[1]) ** 2 + (fy - kykx[0]) ** 2)
     return jnp.exp(1j * phase)
 
 

--- a/src/chromatix/utils/data.py
+++ b/src/chromatix/utils/data.py
@@ -1,6 +1,7 @@
 import numpy as np
 import jax.numpy as jnp
 import os
+import cv2
 
 
 def siemens_star(num_pixels=512, num_spokes=32):
@@ -22,3 +23,160 @@ def siemens_star(num_pixels=512, num_spokes=32):
             S[in_spoke] = 1.0
     S *= R < (num_pixels / 2.0)
     return S
+
+
+def draw_disks(image_size, coordinates, radius, color=255):
+    """
+    Create a grayscale image with disks drawn at each provided coordinate.
+
+    Args:
+        image_size (tuple): The desired image size as (height, width).
+        coordinates (list or numpy.ndarray): A list of (x, y) coordinates where disks should be drawn.
+        radius (int): The radius of the disks.
+        color (int): An optional intensity for the disks (0-255).
+
+    Returns:
+        numpy.ndarray: The resulting grayscale image with disks drawn at the specified coordinates.
+    """
+    # Create a blank grayscale image with the desired size
+    image = np.zeros(image_size, dtype=np.uint8)
+
+    # Draw a disk at each coordinate
+    for coord in coordinates:
+        cv2.circle(image, (coord[0], coord[1]), radius, color, -1)
+
+    return image
+
+class RandDiskGenerator: # TODO avoid overlapping disks
+    def __init__(self,
+                 N,
+                 n_points,
+                 radius,
+                 shape,
+                 z_range):
+        '''
+        Create a dataset of random 3D coordinates and their associated image.
+        Each generated sample consists of an array of [n_points x y z] with
+        shape: n_points * 3, accompanied by a 3D image with shape `shape`. The
+        last dimension of `shape` represents the z axis. The number of planes
+        will be infered from the `shape` argument. This is meant for Tensorflow
+        and PyTorch data loaders that support generators.
+        
+        Parameters
+        ----------
+        N : int
+            Number of samples in the dataset. Avoid large N as the coordinates
+            on each epoch are pre-stored for speed. On each new epoch the samples
+            are randomized again (new random coordinates are generated) therefore
+            you can easily use small `N` to avoid memory issues.
+        n_points : int
+            Number of points in each sample. For 3D samples these samples will
+            be randomly split between the planes.
+        radius : int
+            Radius of the disks to be drawn on each plane.
+        shape : tuple or list
+            Shape of the output image. Dimensions are [h w n_z] where n_z is the
+            number of planes in 3D. For 2D samples use z=1.
+        z_range : list
+            Minimum and Maximum values for z values [min, max]. The returned
+            coordinates are [x y z] and this parameter determines the range of
+            the z coordinates.
+
+        Returns
+        -------
+        None.
+
+        '''
+        
+        assert len(shape) == 3, 'Shape must specify three dimensions, shape parameter is: {}'.format(len(shape))
+        self.N = N
+        self.radius = radius
+        self.shape = shape
+        self.z_range = z_range
+        self.n_points = n_points
+        self.num_planes = shape[-1]
+        
+        self.__get_randomized_coords()
+        
+    
+    def __get_randomized_coords(self):
+        '''
+        Generate all the random coordinates. This is called when generator
+        is instanciated or end of epoch is reached.
+
+        Returns
+        -------
+        None.
+
+        '''
+        self.centery = np.random.randint(low = self.radius,
+                                         high = self.shape[0]-self.radius,
+                                         size = (self.N, self.n_points))
+        self.centerx = np.random.randint(low = self.radius,
+                                         high = self.shape[1]-self.radius,
+                                         size = (self.N, self.n_points))
+        
+        if self.num_planes > 1:
+            self.z_indices = np.random.randint(low = 0,
+                                               high = self.num_planes,
+                                               size = (self.N, self.n_points))
+            self.z_values = np.random.rand(self.N, self.num_planes) * (self.z_range[1] - self.z_range[0])
+            self.z_values += self.z_range[0]
+            self.z_values.sort(axis=1)
+            self.z = np.zeros_like(self.centerx).astype(np.float32)
+        
+
+    def __len__(self):
+        return self.N
+    
+
+    def __getitem__(self, idx):
+        '''
+        Get a new sample.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the current sample that needs to be generated.
+            Automatically provided.
+
+        Returns
+        -------
+        numpy.ndarray
+            A [num_points 2] or [num_points 3] array containing the coordinates.
+        numpy.ndarray
+            2D or 3D Image corresponding to the coordinates.
+
+        '''
+        coords = np.array([self.centerx[idx], self.centery[idx]]).T
+        
+        if self.num_planes > 1:
+            canvas = np.zeros(self.shape)
+            for i in range(self.num_planes):
+                canvas[:, :, i] = draw_disks(self.shape[:-1],
+                                            coords[self.z_indices[idx] == i, :],
+                                            self.radius,
+                                            color = 255) #TODO add weight
+                print(self.z_values[idx, i])
+                self.z[idx, self.z_indices[idx] == i] = self.z_values[idx, i]
+            return np.array([self.centerx[idx], self.centery[idx], self.z[idx]]).T, canvas #TODO add weight
+                
+        else:
+            image = draw_disks(self.shape[:-1],
+                               coords,
+                               self.radius,
+                               color = 255)[..., None] #TODO add weight
+            return coords, image
+    
+    
+    def __call__(self):
+        for i in range(self.__len__()):
+            yield self.__getitem__(i)
+            
+            if i == self.__len__()-1:
+                self.on_epoch_end()
+        
+        
+    #shuffles the dataset at the end of each epoch
+    def on_epoch_end(self):
+        self.__get_randomized_coords()


### PR DESCRIPTION
A module that generates random 3D coordinates and a 3D image associated with it. It's a generator so each sample is generated on the spot. It uses OpenCV and the coordinates are pre-stored in memory so it's the fastest way to implement this if you don't wanna pre-store the images. Another advantage of a generator to pre-storing is that you create a completely new set of samples on every epoch. At the end of each epoch the random coordinates are regenerated.

The only additional dependency is OpenCV. Here `opencv-python` is used.
https://pypi.org/project/opencv-python/