### PR TITLE
Make Field vmappable

### DIFF
--- a/docs/higher_rank.ipynb
+++ b/docs/higher_rank.ipynb
@@ -21,15 +21,7 @@
    "execution_count": 1,
    "id": "76566f6d-0b2b-4057-9ebe-daa45c584d76",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
@@ -130,8 +122,15 @@
      "data": {
       "text/plain": [
        "FrozenDict({\n",
-       "    propagation: {\n",
+       "    state: {\n",
+       "        elements_0: {\n",
+       "            _NA: (),\n",
+       "            _f: (),\n",
+       "            _n: (),\n",
+       "        },\n",
        "        elements_1: {\n",
+       "            _n: (),\n",
+       "            _z: (5,),\n",
        "            kernel: (1, 5, 256, 256, 1, 1),\n",
        "        },\n",
        "    },\n",
@@ -144,7 +143,7 @@
     }
    ],
    "source": [
-    "jax.tree_util.tree_map(lambda x: x.shape, params)"
+    "jax.tree_util.tree_map(lambda x: jnp.array(x).shape, params)"
    ]
   },
   {
@@ -223,7 +222,7 @@
    "id": "33e7f2c1-cd74-4da5-b3d4-e7280fe1d3b9",
    "metadata": {},
    "source": [
-    "## Combining higher rank Fields with vmap/pmap"
+    "## Combining higher rank Fields with vmap"
    ]
   },
   {
@@ -231,7 +230,7 @@
    "id": "2fd64a3f-97a6-400a-bdd8-03fc358f228d",
    "metadata": {},
    "source": [
-    "What if we wanted each element of the outer batch of 2 to be propagated to different z values? The propagation element/functions only accept a 1D array of z values. However, if we try to vmap propagation with a `Field` as an argument, we'll see that we get an error:"
+    "What if we wanted each element of the outer batch of 2 to be propagated to different z values? The propagation element/functions only accept a 1D array of z values. Luckily, `Field` supports being vmapped, with all its attributes such as `dx` or `spectrum` having their shapes appropriately rearranged dynamically. That means you can simply use `jax.vmap` on a function like so:"
    ]
   },
   {
@@ -239,59 +238,22 @@
    "execution_count": 8,
    "id": "32bacd2c-3fe2-4f3e-9819-8a24088a09ec",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "vmap got inconsistent sizes for array axes to be mapped:\n  * most axes (3 of them) had size 2, e.g. axis 0 of argument field.u of type float32[2,1,256,256,1,1];\n  * some axes (2 of them) had size 1, e.g. axis 0 of argument field.spectrum of type float32[1,1,1,1,1,1]",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[8], line 7\u001b[0m\n\u001b[1;32m      4\u001b[0m     field \u001b[38;5;241m=\u001b[39m cx\u001b[38;5;241m.\u001b[39mtransfer_propagate(field, zs, \u001b[38;5;241m1.33\u001b[39m, \u001b[38;5;241m0\u001b[39m)\n\u001b[1;32m      5\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m field\n\u001b[0;32m----> 7\u001b[0m result \u001b[38;5;241m=\u001b[39m \u001b[43msystem\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfield\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mjnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstack\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43mjnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlinspace\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m25\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m50\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnum\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m5\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mjnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlinspace\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m25\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m25\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mnum\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m5\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
-      "    \u001b[0;31m[... skipping hidden 2 frame]\u001b[0m\n",
-      "File \u001b[0;32m~/miniconda3/envs/chromatix2/lib/python3.9/site-packages/jax/_src/api.py:1847\u001b[0m, in \u001b[0;36m_mapped_axis_size\u001b[0;34m(fn, tree, vals, dims, name)\u001b[0m\n\u001b[1;32m   1845\u001b[0m   \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m   1846\u001b[0m     msg\u001b[38;5;241m.\u001b[39mappend(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m  * some axes (\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mct\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m of them) had size \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msz\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m, e.g. axis \u001b[39m\u001b[38;5;132;01m{\u001b[39;00max\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mex\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m;\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m-> 1847\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(msg)[:\u001b[38;5;241m-\u001b[39m\u001b[38;5;241m2\u001b[39m])\n",
-      "\u001b[0;31mValueError\u001b[0m: vmap got inconsistent sizes for array axes to be mapped:\n  * most axes (3 of them) had size 2, e.g. axis 0 of argument field.u of type float32[2,1,256,256,1,1];\n  * some axes (2 of them) had size 1, e.g. axis 0 of argument field.spectrum of type float32[1,1,1,1,1,1]"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@jax.vmap\n",
-    "def system(field: Field, zs: Array) -> Field:\n",
+    "def vmapped_system(field: Field, zs: Array) -> Field:\n",
     "    field = cx.ff_lens(field, 100.0, 1.33, 0.8)\n",
     "    field = cx.transfer_propagate(field, zs, 1.33, 0)\n",
     "    return field\n",
     "\n",
-    "result = system(field, jnp.stack([jnp.linspace(25, 50, num=5), jnp.linspace(-25, 25, num=5)]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4c4eacaa-092c-47e0-9c42-8f8131a8e0f7",
-   "metadata": {},
-   "source": [
-    "This occurs because some elements of the `Field`  are meant to broadcast (like the sampling or the spectrum), and do not have the same size as the actual complex field along the batch dimension to map over. We can fix this by instead creating a function that takes as input and returns an `Array`, instead of a `Field`:"
+    "# Using a stack of z values to propagate each element of the batch\n",
+    "# to different z values using our vmapped function above\n",
+    "result = vmapped_system(field, jnp.stack([jnp.linspace(0, 25, num=5), jnp.linspace(-25, 25, num=5)]))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "e4f98084-7724-455e-aab7-b9a59e541fd8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "@jax.vmap\n",
-    "def array_system(u: Array, zs: Array) -> Field:\n",
-    "    field = ScalarField.create(0.1, 0.532, 1.0, u=u)\n",
-    "    field = cx.ff_lens(field, 100.0, 1.33, 0.8)\n",
-    "    field = cx.transfer_propagate(field, zs, 1.33, 0)\n",
-    "    return field\n",
-    "\n",
-    "result = array_system(field.u, jnp.stack([jnp.linspace(0, 25, num=5), jnp.linspace(-25, 25, num=5)]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
    "id": "9da1051c-0a53-4d8d-9e87-246eb51ffdda",
    "metadata": {},
    "outputs": [
@@ -301,7 +263,7 @@
        "(2, 5, 256, 256, 1, 1)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -312,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "8bc0b9bc-79c9-4135-878c-162f17857135",
    "metadata": {},
    "outputs": [

--- a/src/chromatix/field.py
+++ b/src/chromatix/field.py
@@ -57,27 +57,30 @@ class Field(struct.PyTreeNode):
     to the correct shapes.
 
     Attributes:
-        u: The complex field of shape `(B... H W C [1 | 3])`.
-        dx: The spacing of the samples in ``u`` discretizing a continuous
-            field. Can either be a 1D array with the same size as the number
-            of wavelengths in the spectrum of shape (C), specifying a square
-            spacing per wavelength, or a 2D array of shape (2 C) specifying
-            the spacing in the y and x directions respectively for non-
-            square pixels. A float can also be specified to use the same
-            square spacing for all wavelengths. Spacing will be the same per
-            wavelength for all entries in a batch.
-        spectrum: The wavelengths sampled by the field, in any units specified.
-        spectral_density: The weights of the wavelengths in the spectrum. Must
-            sum to 1.0.
-        spatial_dims: A tuple of two integers specifying the spatial dimensions
-            (the `H W` dimensions respectively) within a `Field` that
-            potentially has multiple batch dimensions.
+        u: The complex field of shape ``(B... H W C [1 | 3])``.
+        _dx: The spacing of the samples in ``u`` discretizing a continuous
+            field. Defined as a 2D array of shape ``(2 C)`` specifying the spacing
+            in the y and x directions respectively (can be the same for y and
+            x for the common case of square pixels). Spacing is the same per
+            wavelength for all entries in a batch. Not intended to be publicly
+            accessed, because the shape of this attribute does not dynamically
+            adapt to the ``ndim`` of the ``Field``. Instead, use the ``dx``
+            property.
+        _spectrum: The wavelengths sampled by the field, in any units specified.
+            Should be a 1D array. Not intended to be publicly accessed, because
+            the shape of this attribute does not dynamically adapt to the
+            ``ndim`` of the ``Field``. Instead, use the ``spectrum`` property.
+        _spectral_density: The weights of the wavelengths in the spectrum.
+            Shouldbe a 1D array of same length as ``_spectrum``. Must sum to
+            1.0. Not intended to be publicly accessed, because the shape of
+            this attribute does not dynamically adapt to the ``ndim`` of the
+            ``Field``. Instead, use the ``spectral_density`` property.
     """
 
     u: Array  # (B... H W C [1 | 3])
-    dx: Array  # (2 B... H W C [1 | 3])
-    spectrum: Array  # (B... H W C [1 | 3])
-    spectral_density: Array  # (B... H W C [1 | 3])
+    _dx: Array = struct.field(pytree_node=False)  # (2 B... H W C [1 | 3])
+    _spectrum: Array = struct.field(pytree_node=False)  # (B... H W C [1 | 3])
+    _spectral_density: Array = struct.field(pytree_node=False)  # (B... H W C [1 | 3])
 
     @property
     def grid(self) -> Array:
@@ -100,6 +103,13 @@ class Field(struct.PyTreeNode):
 
     @property
     def k_grid(self) -> Array:
+        """
+        The frequency grid for each spatial dimension as an array of shape `(2 B... H W
+        C 1)`. The 2 entries along the first dimension represent the y and x
+        grids, respectively. This grid assumes that the center of the ``Field``
+        is the origin and that the elements are sampling from the center, not
+        the corner.
+        """
         N_y, N_x = self.spatial_shape
         grid = jnp.meshgrid(
             jnp.linspace(-N_y // 2, N_y // 2 - 1, num=N_y) + 0.5,
@@ -110,10 +120,42 @@ class Field(struct.PyTreeNode):
         return self.dk * grid
 
     @property
+    def dx(self) -> Array:
+        """
+        The spacing of the samples in ``u`` discretizing a continuous field.
+        Defined as an array of shape ``(2 1... 1 1 C 1 1)`` specifying the spacing
+        in the y and x directions respectively (can be the same for y and x for
+        the common case of square pixels). Spacing is the same per wavelength
+        for all entries in a batch.
+        """
+        return _broadcast_2d_to_grid(self._dx, self.ndim)
+
+    @property
     def dk(self) -> Array:
+        """
+        The frequency spacing of the samples in the frequency space of ``u``.
+        Defined as an array of shape ``(2 1... 1 1 C 1 1)`` specifying the
+        spacing in the y and x directions respectively (can be the same for y
+        and x for the common case of square pixels). Spacing is the same per
+        wavelength for all entries in a batch.
+        """
         shape = jnp.array(self.spatial_shape)
         shape = _broadcast_1d_to_grid(shape, self.ndim)
         return 1 / (self.dx * shape)
+
+    @property
+    def spectrum(self) -> Array:
+        """
+        Wavelengths sampled by the complex field, shape ``(1... 1 1 C 1 1)``.
+        """
+        return _broadcast_1d_to_channels(self._spectrum, self.ndim)
+
+    @property
+    def spectral_density(self) -> Array:
+        """
+        Weights of wavelengths sampled by the complex field, shape ``(1... 1 1 C 1 1)``.
+        """
+        return _broadcast_1d_to_channels(self._spectral_density, self.ndim)
 
     @property
     def phase(self) -> Array:
@@ -150,11 +192,12 @@ class Field(struct.PyTreeNode):
 
     @property
     def spatial_dims(self) -> Tuple[int, int]:
-        """Returns dimensions representing height and width."""
+        """Dimensions representing the height and width of the complex field."""
         return (-4, -3)
 
     @property
     def ndim(self) -> int:
+        """Number of dimensions (the rank) of the complex field."""
         return self.u.ndim
 
     def __add__(self, other: Union[Number, jnp.ndarray, Field]) -> Field:
@@ -278,13 +321,10 @@ class ScalarField(Field):
         ), "Field must be Array with at least 5 dimensions: (B... H W C 1)."
         assert u.shape[-1] == 1, "Last dimension must be 1 for scalar fields."
         assert_equal_shape([spectrum, spectral_density])
-        spectrum = _broadcast_1d_to_channels(spectrum, ndim)
-        spectral_density = _broadcast_1d_to_channels(spectral_density, ndim)
         spectral_density = spectral_density / jnp.sum(spectral_density)
         if dx.ndim == 1:
             dx = jnp.stack([dx, dx])
         assert_rank(dx, 2)  # dx should have shape (2, C) here
-        dx = _broadcast_2d_to_grid(dx, ndim)
         return cls(u, dx, spectrum, spectral_density)
 
 
@@ -342,13 +382,10 @@ class VectorField(Field):
         ), "Field must be Array with at least 5 dimensions: (B... H W C 3)."
         assert u.shape[-1] == 3, "Last dimension must be 3 for vectorial fields."
         assert_equal_shape([spectrum, spectral_density])
-        spectrum = _broadcast_1d_to_channels(spectrum, ndim)
-        spectral_density = _broadcast_1d_to_channels(spectral_density, ndim)
         spectral_density = spectral_density / jnp.sum(spectral_density)
         if dx.ndim == 1:
             dx = jnp.stack([dx, dx])
         assert_rank(dx, 2)  # dx should have shape (2, C) here
-        dx = _broadcast_2d_to_grid(dx, ndim)
         return cls(u, dx, spectrum, spectral_density)
 
     @property

--- a/src/chromatix/ops/fft.py
+++ b/src/chromatix/ops/fft.py
@@ -3,6 +3,7 @@ from typing import Tuple
 from chex import Array
 from functools import partial
 from ..field import Field
+from ..utils.shapes import _squeeze_grid_to_2d
 
 
 def optical_fft(field: Field, z: float, n: float) -> Field:
@@ -24,7 +25,7 @@ def optical_fft(field: Field, z: float, n: float) -> Field:
     norm = jnp.prod(field.dx, axis=0, keepdims=False) / jnp.abs(L) ** 2
     u = -1j * norm * fft(field.u, axes=field.spatial_dims, shift=True)
     du = field.dk * jnp.abs(L) ** 2  # New spacing
-    return field.replace(u=u, dx=du)
+    return field.replace(u=u, _dx=_squeeze_grid_to_2d(du, field.ndim))
 
 
 def fft(x: Array, axes: Tuple[int, int] = (1, 2), shift: bool = False) -> Array:

--- a/src/chromatix/utils/shapes.py
+++ b/src/chromatix/utils/shapes.py
@@ -9,6 +9,7 @@ __all__ = [
     "_broadcast_1d_to_innermost_batch",
     "_broadcast_1d_to_grid",
     "_broadcast_2d_to_grid",
+    "_squeeze_grid_to_2d",
     "_broadcast_2d_to_spatial",
 ]
 
@@ -32,16 +33,29 @@ def _broadcast_1d_to_innermost_batch(x: Union[float, Array], ndim: int) -> Array
 
 
 def _broadcast_1d_to_grid(x: Union[float, Array], ndim: int) -> Array:
-    """Broadcast 1D array of size `2` to `(2 B... H W C 1).
-    Useful for vectorial ops on grids."""
+    """
+    Broadcast 1D array of size `2` to `(2 B... H W C 1)`.
+    Useful for vectorial ops on grids.
+    """
     shape_spec = "d ->" + "d" + " 1" * (ndim - 4) + " 1 1 1 1"
     return rearrange(jnp.atleast_1d(x), shape_spec, d=2)
 
 
 def _broadcast_2d_to_grid(x: Union[float, Array], ndim: int) -> Array:
-    """Broadcast 2D array of shape `2 C` to `(2 B... H W C [1 | 3]).
-    Useful for vectorial ops on grids."""
+    """
+    Broadcast 2D array of shape `2 C` to `(2 B... H W C [1 | 3])`.
+    Useful for vectorial ops on grids.
+    """
     shape_spec = "d c ->" + "d" + " 1" * (ndim - 4) + " 1 1 c 1"
+    return rearrange(x, shape_spec, d=2)
+
+
+def _squeeze_grid_to_2d(x: Union[float, Array], ndim: int) -> Array:
+    """
+    Squeeze array of shape `(2 B... H W C [1 | 3])` to 2D array of shape `2 C`.
+    Useful for vectorial ops on grids.
+    """
+    shape_spec = "d" + " 1" * (ndim - 4) + " 1 1 c 1 -> d c"
     return rearrange(x, shape_spec, d=2)
 
 


### PR DESCRIPTION
Fixes issue #98.

Fields were not `vmap`pable because of the `dx`, `spectrum`, and `spectral_density` attributes. These should not have been treated as `PyTree` nodes, which would require them to have the same batch dimension sizes as the complex field attribute u. Instead, they should be broadcasted across the batch dimensions. We can fix this by specifying to flax.struct that these fields should not count as `PyTree` nodes.

However, this also means that in order for these attributes to have the appropriate broadcasted shapes under a `vmap`, they must be dynamically reshaped based on the current `ndim` of the `Field`. This means that we have had to prefix these attributes with an underscore (to indicate they are no longer for public use) and then add `dx`, `spectrum`, and `spectral_density` properties which get reshaped dynamically to support `vmap`.